### PR TITLE
LINKB-3: Add names to label and work

### DIFF
--- a/mappings/label.ttl
+++ b/mappings/label.ttl
@@ -31,6 +31,8 @@ lb:Label a rr:TriplesMap ;
   rr:predicateObjectMap
     [rr:predicate mo:musicbrainz_guid ;
      rr:objectMap [rr:column "gid" ; rr:datatype xsd:string]] .
+    [rr:predicate rdfs:label ;
+     rr:objectMap [rr:column "name" ; rr:datatype xsd:string]] .
 
 lb:label_area a rr:TriplesMap ;
   rr:logicalTable[rr:sqlQuery

--- a/mappings/medium.ttl
+++ b/mappings/medium.ttl
@@ -29,7 +29,7 @@ lb:Medium a rr:TriplesMap ;
   rr:subjectMap [rr:class mo:Record ;
                  rr:template "http://musicbrainz.org/record/{id}#_"] ;
   rr:predicateObjectMap
-    [rr:predicate dc:title ;
+    [rr:predicate dct:title ;
      rr:objectMap [rr:column "name" ; rr:datatype xsd:string]] ,
     [rr:predicate mo:track_count ;
      rr:objectMap [rr:column "track_count" ; rr:datatype xsd:int]] .

--- a/mappings/recording.ttl
+++ b/mappings/recording.ttl
@@ -32,7 +32,7 @@ lb:Recording a rr:TriplesMap ;
   rr:predicateObjectMap
     [rr:predicate mo:musicbrainz_guid ;
      rr:objectMap [rr:column "gid" ; rr:datatype xsd:string]] ,
-    [rr:predicate dc:title ;
+    [rr:predicate dct:title ;
      rr:objectMap [rr:column "name"]] ,
     [rr:predicate mo:duration ;
      rr:objectMap [rr:column "length"; rr:datatype xsd:float]] .

--- a/mappings/release.ttl
+++ b/mappings/release.ttl
@@ -34,7 +34,7 @@ lb:Release a rr:TriplesMap ;
   rr:predicateObjectMap
     [rr:predicate mo:musicbrainz_guid ;
      rr:objectMap [rr:column "gid"; rr:datatype xsd:string]] ,
-    [rr:predicate dc:title ;
+    [rr:predicate dct:title ;
      rr:objectMap [rr:column "name" ; rr:datatype xsd:string]] .
 
 lb:release_record a rr:TriplesMap ;

--- a/mappings/release_group.ttl
+++ b/mappings/release_group.ttl
@@ -32,7 +32,7 @@ lb:ReleaseGroup a rr:TriplesMap ;
   rr:predicateObjectMap
     [rr:predicate mo:musicbrainz_guid ;
      rr:objectMap [rr:column "gid" ; rr:datatype xsd:string]] ,
-    [rr:predicate dc:title ;
+    [rr:predicate dct:title ;
      rr:objectMap [rr:column "name" ; rr:datatype xsd:string]] .
 
 #BN: removed the 'canonicalisation' that broke non-English Wikipedia URLs

--- a/mappings/track.ttl
+++ b/mappings/track.ttl
@@ -32,7 +32,7 @@ lb:Track a rr:TriplesMap ;
     [rr:predicate mo:track_number;
      rr:objectMap [rr:column "position" ;
                    rr:datatype xsd:nonNegativeInteger]] ,
-    [rr:predicate dc:title ;
+    [rr:predicate dct:title ;
      rr:objectMap [rr:column "name" ; rr:datatype xsd:string]] .
 
 lb:track_length a rr:TriplesMap ;

--- a/mappings/work.ttl
+++ b/mappings/work.ttl
@@ -32,6 +32,9 @@ lb:Work a rr:TriplesMap ;
   rr:predicateObjectMap
     [rr:predicate mo:musicbrainz_guid ;
      rr:objectMap [rr:column "gid" ; rr:datatype xsd:string]] .
+    [rr:predicate dct:title ;
+     rr:objectMap [rr:column "name" ; rr:datatype xsd:string]] .
+
 
 lb:work_composition a rr:TriplesMap ;
   rr:logicalTable [rr:tableName "work"] ;


### PR DESCRIPTION
Using dct:title for work (since it's an actual title) and rdfs:label for label (since it's a more general name) like place has - but we might want to instead standardise everything to dct:title.